### PR TITLE
Set path option to null to stream to stdout/stderr

### DIFF
--- a/lib/koa-json-logger.js
+++ b/lib/koa-json-logger.js
@@ -45,6 +45,14 @@ module.exports = function koaLogger(opts) {
   var config = _.extend(configDefaults, opts),
     env = process.env.NODE_ENV;
 
+  var outStream = { level: 'info' };
+  if (config.path == null) {
+    outStream.stream = process.stdout;
+  }
+  else {
+    outStream.path = path.join(config.path, config.name + '.log');
+  }
+
   // Standard Logger
   var outLogger = bunyan.createLogger({
 
@@ -55,13 +63,16 @@ module.exports = function koaLogger(opts) {
       res: resSerializer
     },
 
-    streams: [
-      {
-        level: 'info',
-        path: path.join(config.path, config.name + '.log')
-      }
-    ]
+    streams: [outStream]
   });
+
+  var errStream = { level: 'error' };
+  if (config.path == null) {
+    errStream.stream = process.stderr;
+  }
+  else {
+    errStream.path = path.join(config.path, config.name + '_error.log');
+  }
 
   // Error Logger
   var errLogger = bunyan.createLogger({
@@ -75,12 +86,7 @@ module.exports = function koaLogger(opts) {
       err: bunyan.stdSerializers.err
     },
 
-    streams: [
-      {
-        level: 'error',
-        path: path.join(config.path, config.name + '_error.log')
-      }
-    ]
+    streams: [errStream]
   });
 
   return function *logger(next) {


### PR DESCRIPTION
AWS, Heroku, and many other logging endpoints and aggregators expect to receive logs on `stdout`/`stderr`. This change allows passing `path: null` as an option to do this easily as a Bunyan stream.
